### PR TITLE
fix: adding CSP with directives for security, x-content-type-options and x-frame-options

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "mui-datatables": "^4.1.2",
     "next": "12.0.9",
     "next-auth": "^4.3.4",
+    "next-safe": "^3.3.0",
     "nodemailer": "6.7.2",
     "papaparse": "^5.3.1",
     "pino": "^7.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9667,6 +9667,11 @@ next-auth@^4.3.4:
     preact-render-to-string "^5.1.19"
     uuid "^8.3.2"
 
+next-safe@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/next-safe/-/next-safe-3.3.0.tgz#7bd4f2ba8b1950027a1929c24009506bbd3c6c06"
+  integrity sha512-IM+ohDK3GMoLk38/anwkvdPF7k6xxUSB/XmyfowssUpnYGbmRHNVJG5OsYv9HGjMg4Ug0h+xh4Cat7hRH/CPhg==
+
 next@12.0.9:
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/next/-/next-12.0.9.tgz#4eb3006b63bb866f5c2918ca0003e98f4259e063"


### PR DESCRIPTION
Adding CSP with directives for security, base-uri, child-src, connect-src, default-src, font-src,
form-action, frame-ancestors, frame-src, img-src, manifest-src, media-src, object-src, prefetch-src,
style-src, worker-src, x-content-type-options and x-frame-options

PEL-345 PEL-346 PEL-348