### PR TITLE
PEL-445 | remove deployment step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   semantic-release:
-    needs: digital-ocean-deployment
+    needs: install-dependencies
     uses: ./.github/workflows/semantic-release.yml
     secrets:
       PROJECT_GITHUB_TOKEN: ${{ secrets.PROJECT_GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request simplifies the `.github/workflows/release.yml` file by removing the `deployment-credentials` and `digital-ocean-deployment` jobs. These jobs previously handled branch-specific deployment configurations and DigitalOcean app deployments. The `semantic-release` job now directly depends on the removed `digital-ocean-deployment` job.

### Workflow simplification:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-L61): Removed the `deployment-credentials` job, which extracted branch-specific variables and set DigitalOcean deployment credentials.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-L61): Removed the `digital-ocean-deployment` job, which handled DigitalOcean app deployment using branch-specific configuration files.